### PR TITLE
Change how filters are added to the url

### DIFF
--- a/Net.Pokeshot.JiveSdk/App.config
+++ b/Net.Pokeshot.JiveSdk/App.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>

--- a/Net.Pokeshot.JiveSdk/Clients/ActivitiesClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/ActivitiesClient.cs
@@ -46,13 +46,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
 
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
 
             if (fields != null && fields.Count > 0)
@@ -188,13 +185,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             }
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item.ToString() + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             url += "&abridged=" + abridged.ToString();
 
@@ -326,13 +320,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             url += "&count=" + ((count > 1000) ? 1000 : count).ToString();
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {

--- a/Net.Pokeshot.JiveSdk/Clients/ContentsClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/ContentsClient.cs
@@ -151,13 +151,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
                 url += "&anchor=" + anchor;
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {
@@ -410,7 +407,8 @@ namespace Net.Pokeshot.JiveSdk.Clients
                     filter.Add("creationDate(" + (creationDate.Item2 == null ? "null" : jiveDateFormat(creationDate.Item2)) + "," +
                         (creationDate.Item1 == null ? "null" : jiveDateFormat(creationDate.Item1) + ")"));
                 }
-                else {
+                else
+                {
                     DateTime earliest = (creationDate.Item1 < creationDate.Item2) ? creationDate.Item1 : creationDate.Item2;
                     DateTime latest = (earliest == creationDate.Item1) ? creationDate.Item2 : creationDate.Item1;
                     filter.Add("creationDate(" + jiveDateFormat(latest) + "," + jiveDateFormat(earliest) + ")");
@@ -424,7 +422,8 @@ namespace Net.Pokeshot.JiveSdk.Clients
                     filter.Add("creationDate(" + (modificationDate.Item2 == null ? "null" : jiveDateFormat(creationDate.Item2)) + "," +
                         (modificationDate.Item1 == null ? "null" : jiveDateFormat(creationDate.Item1) + ")"));
                 }
-                else {
+                else
+                {
                     DateTime earliest = (modificationDate.Item1 < modificationDate.Item2) ? modificationDate.Item1 : modificationDate.Item2;
                     DateTime latest = (earliest == modificationDate.Item1) ? modificationDate.Item2 : modificationDate.Item1;
                     filter.Add("modificationDate(" + jiveDateFormat(latest) + "," + jiveDateFormat(earliest) + ")");
@@ -440,13 +439,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             url += "&includeBlogs=" + includeBlogs.ToString();
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {
@@ -526,13 +522,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             url += "&abridged=" + abridged.ToString();
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {

--- a/Net.Pokeshot.JiveSdk/Clients/MessagesClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/MessagesClient.cs
@@ -43,13 +43,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
                 url += "&anchor=" + anchor;
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {
@@ -182,13 +179,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
                 url += "&anchor=" + anchor;
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {

--- a/Net.Pokeshot.JiveSdk/Clients/PlacesClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/PlacesClient.cs
@@ -149,13 +149,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             url += "&sort=" + sort.ToString();
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {
@@ -273,13 +270,10 @@ namespace Net.Pokeshot.JiveSdk.Clients
             url += "&sort=" + sort.ToString();
             if (filter != null && filter.Count > 0)
             {
-                url += "&filter=";
                 foreach (var item in filter)
                 {
-                    url += item + ",";
+                    url += "&filter=" + item;
                 }
-                // remove last comma
-                url = url.Remove(url.Length - 1);
             }
             if (fields != null && fields.Count > 0)
             {

--- a/Net.Pokeshot.JiveSdk/Net.Pokeshot.JiveSdk.csproj
+++ b/Net.Pokeshot.JiveSdk/Net.Pokeshot.JiveSdk.csproj
@@ -35,60 +35,59 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NewRelic.Api.Agent">
-      <HintPath>..\packages\NewRelic.Agent.Api.3.9.146.0\lib\NewRelic.Api.Agent.dll</HintPath>
+    <Reference Include="NewRelic.Api.Agent, Version=5.18.36.0, Culture=neutral, PublicKeyToken=06552fced0b33d87, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NewRelic.Agent.Api.5.18.36.0\lib\NewRelic.Api.Agent.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Net.Pokeshot.JiveSdk/packages.config
+++ b/Net.Pokeshot.JiveSdk/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="NewRelic.Agent.Api" version="3.9.146.0" targetFramework="net45" />
+  <package id="NewRelic.Agent.Api" version="5.18.36.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The parameter name "filter" used to be added
once followed by a comma-separated list of
values, but this caused an error.

To fix it, "&filter=" is added before each filter
value in the string.
