### PR TITLE
Fix ideaVotesClient to reduce the count

### DIFF
--- a/Net.Pokeshot.JiveSdk/Clients/IdeaVotesClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/IdeaVotesClient.cs
@@ -68,7 +68,7 @@ namespace Net.Pokeshot.JiveSdk.Clients
             //construcs the correct url based on the user's specifications
             string url = ideaVotesUrl;
             url += "/" + contentID.ToString();
-            url += "?count=" + count.ToString();
+            url += "?count=" + (count > 1000 ? 1000 : count).ToString();
             if (startIndex != 0)
             {
                 url += "&startIndex=" + startIndex.ToString();


### PR DESCRIPTION
If the count is > 1000, the Jive api returns an
error. Now the function checks the the count
is in range before making the request.
