### PR TITLE
Add RsvpClient and PeopleClient.Update, and fix idea vote creation

### DIFF
--- a/Net.Pokeshot.JiveSdk/Clients/JiveClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/JiveClient.cs
@@ -77,9 +77,17 @@ namespace Net.Pokeshot.JiveSdk.Clients
         public T RunAs<T>(int personId, Func<T> method)
         {
             _imposter = personId;
-            var returnVal = method();
+            T returnVal = default(T);
+            try
+            {
+                returnVal = method();
+            }
+            catch (Exception ex)
+            {
+                _imposter = null;
+                throw;
+            }
             _imposter = null;
-
             return returnVal;
         }
 

--- a/Net.Pokeshot.JiveSdk/Clients/PeopleClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/PeopleClient.cs
@@ -97,7 +97,7 @@ namespace Net.Pokeshot.JiveSdk.Clients
             {
                 try
                 {
-                    person = GetPersonByUsername("anonymous@test.com");
+                    person = GetPersonByEmail("anonymous@test.com");
                 }
                 catch (HttpException)
                 {
@@ -1662,7 +1662,7 @@ namespace Net.Pokeshot.JiveSdk.Clients
             }
             catch (HttpException e)
             {
-                Console.WriteLine(e.Message);
+                //Console.WriteLine(e.Message);
                 switch (e.GetHttpCode())
                 {
                     case 400:
@@ -1836,6 +1836,40 @@ namespace Net.Pokeshot.JiveSdk.Clients
             JObject results = JObject.Parse(json);
 
             return results["list"].ToObject<List<SecurityGroup>>();
+        }
+
+        /// <summary>
+        /// Update the specified user based on the contents of updatedPerson. Only modifiable fields that actually provide a value in the incoming entity are processed
+        /// </summary>
+        /// <param name="updatedPerson">Updated person</param>
+        /// <returns>Person object reflecting the processed changes</returns>
+        public Person Update(Person updatedPerson)
+        {
+            string url = peopleUrl + "/" + updatedPerson.id;
+            string json = JsonConvert.SerializeObject(updatedPerson, new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore, Formatting = Formatting.Indented });
+            try
+            {
+                json = PutAbsolute(url, json);
+            }
+            catch (HttpException e)
+            {
+                Console.WriteLine(e.Message);
+                switch (e.GetHttpCode())
+                {
+                    case 400:
+                        throw new HttpException(e.WebEventCode, "One or more of the input fields is malformed", e);
+                    case 403:
+                        throw new HttpException(e.WebEventCode, "Requesting user is not authorized to make changes to the specified user", e);
+                    case 404:
+                        throw new HttpException(e.WebEventCode, "Specified user does not exist", e);
+                    case 409:
+                        throw new HttpException(e.WebEventCode, "Requested change would cause business rules to be violated (such as more than one user with the same email address)", e);
+                    default:
+                        throw;
+                }
+            }
+
+            return JObject.Parse(json).ToObject<Person>();
         }
 
         //GetSocialUsers()

--- a/Net.Pokeshot.JiveSdk/Clients/PlacesClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/PlacesClient.cs
@@ -125,7 +125,7 @@ namespace Net.Pokeshot.JiveSdk.Clients
                     case 403:
                         throw new HttpException(e.WebEventCode, "You are not allowed to access the specified content or place", e);
                     case 409:
-                        throw new HttpException(e.WebEventCode, "The new entity would conflict with system restrictions (such as two contents of the same type with the same name", e);
+                        throw new HttpException(e.WebEventCode, "The new entity would conflict with system restrictions (such as two contents of the same type with the same name) or would post content more than once every 90 seconds", e);
                     default:
                         throw;
                 }

--- a/Net.Pokeshot.JiveSdk/Clients/RsvpClient.cs
+++ b/Net.Pokeshot.JiveSdk/Clients/RsvpClient.cs
@@ -4,11 +4,49 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Net;
+using Net.Pokeshot.JiveSdk.Models;
+using System.Web;
 
 namespace Net.Pokeshot.JiveSdk.Clients
 {
-    class RsvpClient : JiveClient
+    public class RsvpClient : JiveClient
     {
+        string rsvpUrl { get { return JiveCommunityUrl + "/api/core/ext/event-type-plugin/v3/rsvp"; } }
+
         public RsvpClient(string communityUrl, NetworkCredential credentials) : base(communityUrl, credentials) { }
+
+        public string Create(int contentID, Person person, RsvpResponse response)
+        {
+            string json = "" + (int) response;
+            string url = rsvpUrl + "/" + contentID.ToString();
+            string result;
+
+            try
+            {
+                result = RunAs(person.id, () => PostAbsolute(url, json));
+            }
+            catch (HttpException e)
+            {
+                switch (e.GetHttpCode())
+                {
+                    case 400:
+                        throw new HttpException(e.WebEventCode, "An input field is missing or malformed", e);
+                    case 403:
+                        throw new HttpException(e.WebEventCode, "You are not allowed to perform this operation", e);
+                    case 404:
+                        throw new HttpException(e.WebEventCode, "The specified parent content object (or comment) cannot be found", e);
+                    default:
+                        throw;
+                }
+            }
+            return result;
+        }
+    }
+
+    public enum RsvpResponse
+    {
+        Yes = 1,
+        No = 2,
+        Maybe = 3
     }
 }

--- a/Net.Pokeshot.JiveSdk/Models/GenericContent.cs
+++ b/Net.Pokeshot.JiveSdk/Models/GenericContent.cs
@@ -11,6 +11,7 @@ namespace Net.Pokeshot.JiveSdk.Models
     /// </summary>
     public class GenericContent : Content
     {
+        public string status { get; set; }
         // Specific to Discussions
         public string answer { get; set; }
         public List<string> helpful { get; set; }


### PR DESCRIPTION
**Features**
- Add RsvpClient content such as Create() so that it's no longer a stub class
- Added Update method to PeopleClient to update Jive profiles

**Bug Fixes**
- IdeaVotesClient often wouldn't create votes and voted as the wrong user when it did work (that was months ago, I'm wondering now if I just didn't try ideaClient.RunAs(voter.id, ideaClient.Create(idea)) ). Now it uses the voter.id from the passed vote object
- JiveClient.RunAs() now resets _imposter to null if its passed method throws an exception